### PR TITLE
Fix error in filtering and documentation

### DIFF
--- a/neuronpp/core/cells/complex_synaptic_cell.py
+++ b/neuronpp/core/cells/complex_synaptic_cell.py
@@ -19,7 +19,7 @@ class ComplexSynapticCell(SynapticCell):
             eg. (lambda expression) returns sections which name contains 'apic' or their distance > 1000 um from the soma:
           ```
            soma = cell.filter_secs("soma")
-           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma(0.5), o(0.5)) > 1000)
+           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma.hoc(0.5), o.hoc(0.5)) > 1000)
           ```
 
         * Single object field filter based on callable function passed to the obj_filter param.

--- a/neuronpp/core/cells/core_cell.py
+++ b/neuronpp/core/cells/core_cell.py
@@ -31,7 +31,7 @@ class CoreCell:
             eg. (lambda expression) returns sections which name contains 'apic' or their distance > 1000 um from the soma:
           ```
            soma = cell.filter_secs("soma")
-           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma(0.5), o(0.5)) > 1000)
+           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma.hoc(0.5), o.hoc(0.5)) > 1000)
           ```
 
         * Single object field filter based on callable function passed to the obj_filter param.
@@ -67,7 +67,7 @@ class CoreCell:
             pat_found = 0
 
             # If FilterFunction object with filter() function pass
-            if obj_filter and obj_filter.filter(obj):
+            if obj_filter and obj_filter(obj):
                 pat_found += 1
 
             for attr_name, pat in patterns:

--- a/neuronpp/core/cells/netcon_cell.py
+++ b/neuronpp/core/cells/netcon_cell.py
@@ -26,7 +26,7 @@ class NetConCell(PointProcessCell):
             eg. (lambda expression) returns sections which name contains 'apic' or their distance > 1000 um from the soma:
           ```
            soma = cell.filter_secs("soma")
-           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma(0.5), o(0.5)) > 1000)
+           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma.hoc(0.5), o.hoc(0.5)) > 1000)
           ```
 
         * Single object field filter based on callable function passed to the obj_filter param.

--- a/neuronpp/core/cells/netstim_cell.py
+++ b/neuronpp/core/cells/netstim_cell.py
@@ -18,7 +18,7 @@ class NetStimCell(CoreCell):
             eg. (lambda expression) returns sections which name contains 'apic' or their distance > 1000 um from the soma:
           ```
            soma = cell.filter_secs("soma")
-           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma(0.5), o(0.5)) > 1000)
+           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma.hoc(0.5), o.hoc(0.5)) > 1000)
           ```
 
         * Single object field filter based on callable function passed to the obj_filter param.

--- a/neuronpp/core/cells/point_process_cell.py
+++ b/neuronpp/core/cells/point_process_cell.py
@@ -25,7 +25,7 @@ class PointProcessCell(SectionCell):
             eg. (lambda expression) returns sections which name contains 'apic' or their distance > 1000 um from the soma:
           ```
            soma = cell.filter_secs("soma")
-           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma(0.5), o(0.5)) > 1000)
+           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma.hoc(0.5), o.hoc(0.5)) > 1000)
           ```
 
         * Single object field filter based on callable function passed to the obj_filter param.

--- a/neuronpp/core/cells/section_cell.py
+++ b/neuronpp/core/cells/section_cell.py
@@ -27,7 +27,7 @@ class SectionCell(CoreCell):
             eg. (lambda expression) returns sections which name contains 'apic' or their distance > 1000 um from the soma:
           ```
            soma = cell.filter_secs("soma")
-           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma(0.5), o(0.5)) > 1000)
+           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma.hoc(0.5), o.hoc(0.5)) > 1000)
           ```
 
         * Single object field filter based on callable function passed to the obj_filter param.

--- a/neuronpp/core/cells/synaptic_cell.py
+++ b/neuronpp/core/cells/synaptic_cell.py
@@ -19,7 +19,7 @@ class SynapticCell(NetConCell):
             eg. (lambda expression) returns sections which name contains 'apic' or their distance > 1000 um from the soma:
           ```
            soma = cell.filter_secs("soma")
-           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma(0.5), o(0.5)) > 1000)
+           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma.hoc(0.5), o.hoc(0.5)) > 1000)
           ```
 
         * Single object field filter based on callable function passed to the obj_filter param.

--- a/neuronpp/core/cells/vecstim_cell.py
+++ b/neuronpp/core/cells/vecstim_cell.py
@@ -20,7 +20,7 @@ class VecStimCell(CoreCell):
             eg. (lambda expression) returns sections which name contains 'apic' or their distance > 1000 um from the soma:
           ```
            soma = cell.filter_secs("soma")
-           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma(0.5), o(0.5)) > 1000)
+           cell.filter_secs(obj_filter=lambda o: 'apic' in o.name or h.distance(soma.hoc(0.5), o.hoc(0.5)) > 1000)
           ```
 
         * Single object field filter based on callable function passed to the obj_filter param.

--- a/neuronpp/tests/test_cell.py
+++ b/neuronpp/tests/test_cell.py
@@ -99,5 +99,17 @@ class TestCellAddSectionLeak(unittest.TestCase):
         self.assertEqual(self.soma6.hoc.e_pas, -77)
 
 
+class TestFiltering(unittest.TestCase):
+    def test_distance(self):
+        path = os.path.dirname(os.path.abspath(__file__))
+        filepath = os.path.join(path, "..",
+                                "commons/morphologies/asc/cell1.asc")
+        cell = Cell("cell")
+        cell.load_morpho(filepath=filepath)
+        soma = cell.filter_secs("soma")
+
+        # Filter sections by distance to the soma (return only those distance > 1000 um)
+        far_secs = cell.filter_secs(obj_filter=lambda s: h.distance(soma.hoc(0.5), s.hoc(0.5)) > 1000)
+        self.assertEqual(len(far_secs), 32)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Using filtering with obj_filter specified as a lambda function resulted
in errors. The example for filtering by distance was also incorrect.