### PR TITLE
initnrn results in incorrect simulation results

### DIFF
--- a/neuronpp/utils/simulation.py
+++ b/neuronpp/utils/simulation.py
@@ -110,8 +110,8 @@ class Simulation(NeuronRemovable):
         print("Simulation initialization.")
         if self.check_pointers:
             self._check_point_process_pointers()
-        h.initnrn()
         h.frecord_init()
+        h.fcurrent()
         h.finitialize(self.init_v * mV)
 
         if self.init_sleep > 0:


### PR DESCRIPTION
possibly because it completely restarts and resets neuron