### PR TITLE
fixed connect_secs()

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ All examples are located in: examples/
    ```python
     cell.add_seg("soma", diam=20, l=20, nseg=10)
     cell.add_seg("dend", diam=2, l=100, nseg=10)
-    cell.connect_secs(source="dend", target="soma")
+    cell.connect_secs(child="dend", parent="soma")
    ```
 
   * add NEURON mechanisms (default or MOD-based):

--- a/neuronpp/core/cells/netstim_cell.py
+++ b/neuronpp/core/cells/netstim_cell.py
@@ -11,7 +11,7 @@ class NetStimCell(CoreCell):
         """
         Making NetStim after simulation run() makes it has no effect on the current simulation.
         However it will appear in the next simulation if:
-         * you call reset() on the Simulation object
+         * you call reinit() on the Simulation object
          * or create a new Simulation object
 
         :param name:
@@ -56,7 +56,7 @@ class NetStimCell(CoreCell):
         """
         Making NetStim after simulation run() makes it has no effect on the current simulation.
         However it will appear in the next simulation if:
-         * you call reset() on the Simulation object
+         * you call reinit() on the Simulation object
          * or create a new Simulation object
 
         :param start:
@@ -72,7 +72,7 @@ class NetStimCell(CoreCell):
         if h.t > 0:
             # TODO: Change all warnings and prints to loggers
             print("Warning: NetStim created after simulation have been initiated, will not affect "
-                  "this simulation, but rather the next one after you execute reset() method on "
+                  "this simulation, but rather the next one after you execute reinit() method on "
                   "the Simulation object.")
 
         ns_hoc = get_netstim(start=start, number=number, interval=interval, noise=noise)

--- a/neuronpp/core/cells/spine_cell.py
+++ b/neuronpp/core/cells/spine_cell.py
@@ -2,13 +2,13 @@ import random
 from typing import List, Union
 import numpy as np
 
-from neuronpp.core.cells.section_cell import SectionCell
-from neuronpp.core.decorators import distparams
 from neuronpp.core.hocwrappers.sec import Sec
 from neuronpp.core.hocwrappers.seg import Seg
+from neuronpp.core.decorators import distparams
 from neuronpp.core.hocwrappers.spine import Spine
-from neuronpp.core.cells.utils import establish_electric_properties
 from neuronpp.core.cells.utils import get_spine_number
+from neuronpp.core.cells.section_cell import SectionCell
+from neuronpp.core.cells.utils import establish_electric_properties
 
 # Nomenclature and values adapted from Harris KM, Jensen FE, Tsao BE.
 # J Neurosci 1992
@@ -366,8 +366,7 @@ class SpineCell(SectionCell):
                                                                  spine_tag,
                                                                  i))
             self.spines.append(spine)
-            self.connect_secs(source=neck, target=section, source_loc=location,
-                              target_loc=0.0)
+            self.connect_secs(child=neck, parent=section, child_loc=0.0, parent_loc=location)
 
     @staticmethod
     def _get_spine_factor(spines: List[Spine], mech_name: str, gbar: str = None):

--- a/neuronpp/core/hocwrappers/sec.py
+++ b/neuronpp/core/hocwrappers/sec.py
@@ -1,5 +1,7 @@
+
 import nrn
 from numpy import pi
+from typing import Optional
 
 from neuronpp.core.hocwrappers.seg import Seg
 from neuronpp.core.cells.core_cell import CoreCell
@@ -27,6 +29,9 @@ class Sec(HocWrapper):
 
     @property
     def parent(self):
+        """
+        Returns parent Section or None if there is no parent.
+        """
         parent_seg = self.hoc.parentseg()
         if parent_seg:
             hoc_sec = parent_seg.sec
@@ -35,9 +40,45 @@ class Sec(HocWrapper):
             return None
 
     @property
-    def area(self):
+    def area(self) -> float:
+        """
+        Returns total area of the Section
+        """
         return pi*self.hoc.L*self.hoc.diam
 
-    def __call__(self, loc):
+    @property
+    def orientation(self) -> float:
+        """
+        Return the end (0 or 1) which connects to the parent. This is the value, y, used:
+            * In Neuron++ SectionCell: cell.connect_secs(child, parent, x, y)
+            * In NEURON child.connect(parent(x), y)
+
+        If the Section has no parent it will return 0.
+        """
+        return self.hoc.orientation()
+
+    @property
+    def parent_loc(self) -> Optional[float]:
+        """
+        Returns location on parent that child is connected to. (0 <= x <= 1).
+        This information is also available via: self.hoc.parentseg().x
+
+        If the section has no parent it will return None
+        """
+        parent = self.hoc.parentseg()
+        if parent:
+            return parent.x
+        else:
+            return None
+
+    @property
+    def segs(self):
+        """
+        Returns all Segments wrapper in Seg object
+        :return:
+        """
+        return [Seg(obj=hoc_seg, parent=self) for hoc_seg in self.hoc.allseg()]
+
+    def __call__(self, loc) -> Seg:
         hoc_seg = self.hoc(loc)
         return Seg(obj=hoc_seg, parent=self)

--- a/neuronpp/core/hocwrappers/seg.py
+++ b/neuronpp/core/hocwrappers/seg.py
@@ -4,3 +4,7 @@ from neuronpp.core.hocwrappers.hoc_wrapper import HocWrapper
 class Seg(HocWrapper):
     def __init__(self, obj, parent):
         HocWrapper.__init__(self, hoc_obj=obj, parent=parent, name=str(obj))
+
+    @property
+    def area(self) -> float:
+        return self.hoc.area()

--- a/neuronpp/core/hocwrappers/spine.py
+++ b/neuronpp/core/hocwrappers/spine.py
@@ -19,7 +19,7 @@ class Spine(SecGroup):
         :param name:
             name of the spine
         """
-        cell.connect_secs(source=head, target=neck)
+        cell.connect_secs(child=head, parent=neck, child_loc=0.0, parent_loc=1.0)
         self.head = head
         self.neck = neck
         SecGroup.__init__(self, secs=[head, neck], name=name)

--- a/neuronpp/examples/ach_learning_example.py
+++ b/neuronpp/examples/ach_learning_example.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
     cell = Ebner2019AChDACell("cell")
     cell.add_sec("soma", diam=20, l=20, nseg=10)
     cell.add_sec("dend", diam=8, l=500, nseg=100)
-    cell.connect_secs(source="dend", target="soma", source_loc=0, target_loc=1)
+    cell.connect_secs(child="dend", parent="soma", child_loc=0, parent_loc=1)
 
     # make synapses with spines
     syns_4p, heads = cell.add_random_synapses_with_spine(source=None, secs=cell.secs,

--- a/neuronpp/examples/synaptic_example.py
+++ b/neuronpp/examples/synaptic_example.py
@@ -16,7 +16,7 @@ model_path2 = os.path.join(path, "..",
 cell = Cell(name="cell", compile_paths=model_path1)
 cell.load_morpho(filepath=model_path2)
 cell.add_sec("dend[1]", diam=10, l=10, nseg=10)
-cell.connect_secs(source="dend[1]", target="soma")
+cell.connect_secs(child="dend[1]", parent="soma")
 cell.insert("pas")
 cell.insert("hh")
 

--- a/neuronpp/tests/test_section.py
+++ b/neuronpp/tests/test_section.py
@@ -1,0 +1,83 @@
+import re
+import unittest
+from neuron import h
+
+from neuronpp.cells.cell import Cell
+
+
+class TestSection(unittest.TestCase):
+    def setUp(self):
+        self.cell = Cell(name="cell")
+
+    def tearDown(self):
+        self.cell.remove_immediate_from_neuron()
+
+        l = len(list(h.allsec()))
+        if len(list(h.allsec())) != 0:
+            raise RuntimeError("Not all section have been removed after teardown. "
+                               "Sections left: %s" % l)
+
+    def test_default_name(self):
+        """
+        If the name exists it will add a number starting from 2 to the proposed name.
+        """
+        pat = re.compile("[1-9]")
+
+        for i in range(10):
+            self.cell.add_sec("dend")
+
+        for i, dend in enumerate(self.cell.filter_secs(name="dend")):
+            res = pat.search(dend.name)
+            if i == 0:
+                self.assertIsNone(res)
+            else:
+                self.assertEqual(i+1, int(dend.name.replace("dend", "")))
+            dend.remove_immediate_from_neuron()
+
+    def test_regex_search(self):
+        for i in range(10):
+            self.cell.add_sec("dend")
+
+        for i, dend in enumerate(self.cell.filter_secs("regex:dend[1-9]")):
+            self.assertEqual(i+2, int(dend.name.replace("dend", "")))
+
+        for d in self.cell.secs:
+            d.remove_immediate_from_neuron()
+
+    def test_connections(self):
+        soma = self.cell.add_sec(name="soma", l=10, nseg=10)
+        dend = self.cell.add_sec(name="dend", l=100, nseg=10)
+        self.cell.connect_secs(child=dend, parent=soma, child_loc=0, parent_loc=0.7)
+
+        self.assertEqual(0, dend.orientation)
+        self.assertEqual(0.7, dend.parent_loc)
+        self.assertIsNone(soma.parent_loc)
+
+    def test_allseg(self):
+        soma = self.cell.add_sec(name="soma", diam=1, l=10, nseg=20)
+        dend = self.cell.add_sec(name="dend", diam=1, l=100, nseg=200)
+        self.assertEqual(22, len(soma.segs))
+        self.assertEqual(202, len(dend.segs))
+
+    def test_area1(self):
+        soma = self.cell.add_sec(name="soma", diam=1, l=10, nseg=20)
+        dend = self.cell.add_sec(name="dend", diam=1, l=100, nseg=200)
+
+        self.assertEqual(0, soma.segs[0].area)
+        self.assertEqual(0, soma.segs[-1].area)
+        self.assertEqual(0, dend.segs[0].area)
+        self.assertEqual(0, dend.segs[-1].area)
+
+        for s in soma.segs[1:-1]:
+            self.assertEqual(1.5708, round(s.area, 4))
+        for s in dend.segs[1:-1]:
+            self.assertEqual(1.5708, round(s.area, 4))
+
+    def test_area2(self):
+        apic = self.cell.add_sec(name="apic", diam=10, l=10, nseg=4)
+        for s in apic.segs[1:-1]:
+            self.assertEqual(78.5398, round(s.area, 4))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/neuronpp/tests/test_section.py
+++ b/neuronpp/tests/test_section.py
@@ -31,7 +31,7 @@ class TestSection(unittest.TestCase):
             if i == 0:
                 self.assertIsNone(res)
             else:
-                self.assertEqual(i+1, int(dend.name.replace("dend", "")))
+                self.assertEqual(i + 1, int(dend.name.replace("dend", "")))
             dend.remove_immediate_from_neuron()
 
     def test_regex_search(self):
@@ -39,7 +39,7 @@ class TestSection(unittest.TestCase):
             self.cell.add_sec("dend")
 
         for i, dend in enumerate(self.cell.filter_secs("regex:dend[1-9]")):
-            self.assertEqual(i+2, int(dend.name.replace("dend", "")))
+            self.assertEqual(i + 2, int(dend.name.replace("dend", "")))
 
         for d in self.cell.secs:
             d.remove_immediate_from_neuron()

--- a/neuronpp/tests/test_simulation.py
+++ b/neuronpp/tests/test_simulation.py
@@ -184,7 +184,7 @@ class TestSimulation(unittest.TestCase):
         Netcon created before sim init or start is not effective and should return error
         """
         sim = Simulation()
-        sim.init_simulation()
+        sim.reinit()
         syn = self.cell.add_synapse(source=None, netcon_weight=1.0, mod_name="ExpSyn", delay=1,
                                     seg=self.apic1(0.5))
         error = False

--- a/neuronpp/tests/test_simulation.py
+++ b/neuronpp/tests/test_simulation.py
@@ -184,7 +184,7 @@ class TestSimulation(unittest.TestCase):
         Netcon created before sim init or start is not effective and should return error
         """
         sim = Simulation()
-        sim.reset()
+        sim.init_simulation()
         syn = self.cell.add_synapse(source=None, netcon_weight=1.0, mod_name="ExpSyn", delay=1,
                                     seg=self.apic1(0.5))
         error = False

--- a/neuronpp/tests/test_spine_cell.py
+++ b/neuronpp/tests/test_spine_cell.py
@@ -12,15 +12,13 @@ class TestCellAddSpineToSection(unittest.TestCase):
         cls.cell = SpineCell(name="cell")
         cls.soma = cls.cell.add_sec("soma", add_pas=True, nseg=10)
         cls.cell._add_spines_to_section(cls.soma, "new", 0.5, 1, 1, 0.5, 0.5,
-                                        None, None, None, None,
-                                        add_pas=False)
+                                        None, None, None, None, add_pas=False)
         cls.head = cls.cell.heads[0]
         cls.neck = cls.cell.necks[0]
         cls.cell2 = SpineCell(name="cell2")
         cls.soma2 = cls.cell2.add_sec("soma", nseg=10, add_pas=True)
         cls.cell2._add_spines_to_section(cls.soma2, "new", 0.3, .5, .5, 0.3, 0.3,
-                                         None, None, None, None,
-                                         add_pas=True)
+                                         None, None, None, None, add_pas=True)
         cls.head2 = cls.cell2.heads[0]
         cls.neck2 = cls.cell2.necks[0]
 

--- a/neuronpp/utils/record.py
+++ b/neuronpp/utils/record.py
@@ -17,7 +17,7 @@ class Record(NeuronRemovable):
         """
         Making Record after simulation run() makes it has no effect on the current simulation.
         However it will appear in the next simulation if:
-         * you call reset() on the Simulation object
+         * you call reinit() on the Simulation object
          * or create a new Simulation object
 
         :param elements:
@@ -30,7 +30,7 @@ class Record(NeuronRemovable):
         if h.t > 0:
             # TODO: Change all warnings and prints to loggers
             print("Warning: Record created after simulation have been initiated, will not affect "
-                  "this simulation, but rather the next one after you execute reset() method on "
+                  "this simulation, but rather the next one after you execute reinit() method on "
                   "the Simulation object.")
 
         if not isinstance(elements, (list, set, tuple)):

--- a/neuronpp/utils/simulation.py
+++ b/neuronpp/utils/simulation.py
@@ -27,8 +27,8 @@ class Simulation(NeuronRemovable):
         NEURON's simulator state. So if you create many Simulation objects, all of them will have
         access to the same NEURON's state.
 
-        After creating the object and execute the run() for the first time - init_simulation()
-        will be called. You can also call init_simulation() to re-init the NEURON any time.
+        After creating the object and execute the run() for the first time - reinit()
+        will be called. You can also call reinit() to re-init the NEURON any time.
 
         :param init_v
             initial value in mV for the neuron function finitialize().
@@ -103,14 +103,14 @@ class Simulation(NeuronRemovable):
 
         self.warmup_done = False
 
-    def init_simulation(self):
+    def reinit(self):
         """
         This method restart simulation time to 0, reinitialize the voltage to the init value and
         clear all recorded values in Record objects (its clear inside vector for each segment
         recorded).
 
         After creation of the new Simulation object and call the first time run() method the method
-        init_simulation() is always called.
+        reinit() is always called.
 
         No other Hoc object is removed, eg. all sections remains. If you want to remove NEURON from
         objects you can:
@@ -166,7 +166,7 @@ class Simulation(NeuronRemovable):
             * Simulation stepsize
         """
         if not self.warmup_done:
-            self.init_simulation()
+            self.reinit()
 
             if self.warmup > 0:
                 if self.warmup_dt is None:

--- a/neuronpp/utils/simulation.py
+++ b/neuronpp/utils/simulation.py
@@ -21,10 +21,14 @@ class Simulation(NeuronRemovable):
                  constant_timestep: bool = True, with_neuron_gui: bool = False,
                  check_pointers: bool = False):
         """
-        Create an object to control the simulation.
+        Create an Simulation object to control the NEURON's simulation.
 
-        After creating the object and execure run() for the first time - the NEURON simulator
-        will be reset(). You can also reset the simulator whether you want calling reset() method.
+        Simulation WILL NOT create a NEURON environment but rather allows to access to the
+        NEURON's simulator state. So if you create many Simulation objects, all of them will have
+        access to the same NEURON's state.
+
+        After creating the object and execute the run() for the first time - init_simulation()
+        will be called. You can also call init_simulation() to re-init the NEURON any time.
 
         :param init_v
             initial value in mV for the neuron function finitialize().
@@ -99,13 +103,23 @@ class Simulation(NeuronRemovable):
 
         self.warmup_done = False
 
-    def reset(self):
+    def init_simulation(self):
         """
-        After each creation of the Simulation object or call the reset() method
-        the Record object is cleaned up (its inside vector for each segment recorded)
-        however on other Hoc object is removed eg. Sections.
+        This method restart simulation time to 0, reinitialize the voltage to the init value and
+        clear all recorded values in Record objects (its clear inside vector for each segment
+        recorded).
 
-        That means - each new sections and cell are retained in the current NEURON run.
+        After creation of the new Simulation object and call the first time run() method the method
+        init_simulation() is always called.
+
+        No other Hoc object is removed, eg. all sections remains. If you want to remove NEURON from
+        objects you can:
+          * call remove_immediate_from_neuron() method on each Wrapper object (eg. Sec, Seg, NetCon)
+          * call remove_immediate_from_neuron() method on each Cell object, which automatically
+            removes also containing wrappers
+          * delete or reassign all references to the object you want to delete
+
+        To check how many Sections in NEURON remains check simulation.size property.
         """
         print("Simulation initialization.")
         if self.check_pointers:
@@ -152,7 +166,7 @@ class Simulation(NeuronRemovable):
             * Simulation stepsize
         """
         if not self.warmup_done:
-            self.reset()
+            self.init_simulation()
 
             if self.warmup > 0:
                 if self.warmup_dt is None:


### PR DESCRIPTION
1. fixed connect_secs() method in SectionCell: 
  - changed naming convention to child, parent, 
  - fixed child_loc and parent_loc assignment; 
  - added to Sec methods: 
    - segs() - returns all segments in the Section, parent_loc() - returns location on the parent where the Segment is attached; 
    - orientation() - returns the 0 or 1 end where the child (this Section) is attached to the parent; 
  - added area() method to the Seg object; 
2. extended docstring for the Simulation and renamed reset() method to init_simulation() method; 
3. added tests for Sections; fixed location while spine cration: in Spine object and in the SpineCell object